### PR TITLE
Use conditional switch on send_file to ensure 304 responses are emitted

### DIFF
--- a/flask_bower/__init__.py
+++ b/flask_bower/__init__.py
@@ -16,7 +16,7 @@ def serve(component, filename):
 
     root = current_app.config['BOWER_COMPONENTS_ROOT']
 
-    return send_file('/'.join([root, component, filename]))
+    return send_file('/'.join([root, component, filename]), conditional=True)
 
 
 def bower_url_for(component, filename, **values):


### PR DESCRIPTION
This patch ensures that 304 responses are emitted on requests for bower components.
