### PR TITLE
Remove attempt to reraise BuildError in the context of the original traceback

### DIFF
--- a/flask_bower/__init__.py
+++ b/flask_bower/__init__.py
@@ -57,11 +57,7 @@ def handle_url_error(error, endpoint, values):
     """
     url = overlay_url_for(endpoint, **values)
     if url is None:
-        exc_type, exc_value, tb = sys.exc_info()
-        if exc_value is error:
-            raise exc_type(exc_value).with_traceback(tb)
-        else:
-            raise error
+        raise error
     # url_for will use this result, instead of raising BuildError.
     return url
 


### PR DESCRIPTION
This causes `TypeError: __init__() takes exactly 4 arguments (2 given)` instead of the original `BuildError`. Flask already fixes the traceback, despite what the docs say.
