### PR TITLE
use / as separator instead of os.path.sep to parse filename

### DIFF
--- a/flask_bower/__init__.py
+++ b/flask_bower/__init__.py
@@ -83,8 +83,8 @@ def overlay_url_for(endpoint, filename=None, **values):
 
     if endpoint == 'static' or endpoint.endswith('.static'):
 
-        if os.path.sep in filename:
-            filename_parts = filename.split(os.path.sep)
+        if '/' in filename:
+            filename_parts = filename.split('/')
             component = filename_parts[0]
             # Using * magic here to expand list
             filename = os.path.join(*filename_parts[1:])


### PR DESCRIPTION
A fix for #7 where we'd have to agree on always using "/" as separator in url_for, instead of os.path.sep. So on Windows we can use `url_for('bower.static', filename='jquery/dist/jquery.js')` as well.