### PR TITLE
Fix ModuleNotFoundError: use six.reraise instead

### DIFF
--- a/flask_bower/__init__.py
+++ b/flask_bower/__init__.py
@@ -4,7 +4,7 @@ import os
 from flask import abort, json, send_file, Blueprint, current_app, url_for
 import sys
 
-from flask._compat import reraise
+from six import reraise
 
 
 def validate_parameter(param):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 -e git://github.com/mitsuhiko/flask.git#egg=flask
+six


### PR DESCRIPTION
Import `reraise` from six instead of flask._compat, which no longer exist now.

The `flask._compat.reraise` was implemented in Flask to mitigate the missing feature of `six` for py2/3 compatibility. See: https://github.com/pallets/flask/commit/a503520ac51d16558ce91f7d7fc9d30a910d928c

Before the fix, test will raise `ModuleNotFoundError`:

```console
$ nose2 tests -s .
E
======================================================================
ERROR: test_build_url (nose2.loader.ModuleImportFailure)
----------------------------------------------------------------------
ImportError: Failed to import test module: test_build_url
Traceback (most recent call last):
  File "/Users/jeff_hung/wc/flask-bower/runtime/lib/python3.10/site-packages/nose2/plugins/loader/discovery.py", line 204, in _find_tests_in_file
    module = util.module_from_name(module_name)
  File "/Users/jeff_hung/wc/flask-bower/runtime/lib/python3.10/site-packages/nose2/util.py", line 76, in module_from_name
    __import__(name)
  File "/Users/jeff_hung/wc/flask-bower/tests/test_build_url.py", line 6, in <module>
    from flask_bower import Bower, bower_url_for
  File "/Users/jeff_hung/wc/flask-bower/flask_bower/__init__.py", line 7, in <module>
    from flask._compat import reraise
ModuleNotFoundError: No module named 'flask._compat'


----------------------------------------------------------------------
Ran 1 test in 0.000s

FAILED (errors=1)
```

After applied the fix, tests are now all passed:

```console
$ nose2 tests -s .
........
----------------------------------------------------------------------
Ran 8 tests in 0.033s

OK
```

( Nose does not work in Python 3.10 so I test with nose2 instead. )